### PR TITLE
parse date as %F (YYYY-MM-DD)

### DIFF
--- a/Channels.hs
+++ b/Channels.hs
@@ -26,7 +26,7 @@ channelsPage = openURL "http://nixos.org/channels/"
 
 parseTime :: String -> Either String UTCTime
 parseTime = liftM (localTimeToUTC tz) . parseTimeM True defaultTimeLocale format . strip'
-  where format = "%d-%b-%Y %R"
+  where format = "%F %R"
         tz = hoursToTimeZone 1 -- CET
         strip' = unpack . strip . pack
 


### PR DESCRIPTION
Raising this PR as the dates at https://nixos.org/channels/ has changed

Running master without this results to `parseTimeM: no parse of "2016-03-27 12:53"`

This might also fix #6
