### PR TITLE
Major refactoring

### DIFF
--- a/Channels.hs
+++ b/Channels.hs
@@ -31,7 +31,7 @@ data RawChannel = RawChannel { rname :: Text
                              } deriving (Show)
 
 data Channel = Channel { name  :: Text
-                       , label :: Color
+                       , label :: Label
                        , humantime  :: Text
                        , time :: Maybe NominalDiffTime
                        , commit :: String
@@ -40,8 +40,13 @@ data Channel = Channel { name  :: Text
                        } deriving (Show, Generic)
 instance ToJSON Channel
 
-type Color = Text
-
+data Label = Danger | Warning | Success | NoLabel deriving (Generic)
+instance Show Label where
+  show Danger = "danger"
+  show Warning = "warning"
+  show Success = "success"
+  show NoLabel = ""
+instance ToJSON Label
 
 parseTime :: String -> Either Text UTCTime
 parseTime = fmap (localTimeToUTCTZ tz) . parseTimeM True defaultTimeLocale "%F %R"
@@ -116,10 +121,10 @@ toJobset c
  | otherwise                   = Nothing
 
 -- | Takes time since last update to the channel and colors it based on it's age
-diffToLabel :: Either Text NominalDiffTime -> Color
-diffToLabel (Left _) = ""
+diffToLabel :: Either Text NominalDiffTime -> Label
+diffToLabel (Left _) = NoLabel
 diffToLabel (Right time)
-  | days < 3 = "success"
-  | days < 10 = "warning"
-  | otherwise = "danger"
+  | days < 3 = Success
+  | days < 10 = Warning
+  | otherwise = Danger
     where days = time / (60 * 60 * 24)

--- a/Channels.hs
+++ b/Channels.hs
@@ -26,7 +26,7 @@ type Color = String
 
 
 parseTime :: String -> Either String UTCTime
-parseTime = liftM (localTimeToUTCTZ tz) . parseTimeM True defaultTimeLocale "%F %R"
+parseTime = fmap (localTimeToUTCTZ tz) . parseTimeM True defaultTimeLocale "%F %R"
   where tz = tzByLabel Europe__Rome -- CET/CEST
 
 findGoodChannels :: String -> [Channel]

--- a/Main.hs
+++ b/Main.hs
@@ -11,7 +11,7 @@ import System.Environment (getEnvironment)
 import Text.Hamlet (shamletFile)
 import Text.Blaze.Html.Renderer.Text (renderHtml)
 
-import Channels (DiffChannel (..), channels, jobset)
+import Channels (Channel (..), channels, jobset)
 
 
 main = do
@@ -21,3 +21,6 @@ main = do
     get "/" $ do
       allChannels <- liftIO $ channels
       html $ renderHtml $(shamletFile "index.hamlet")
+    get "/api/channels" $ do
+      allChannels <- liftIO $ channels
+      json $ allChannels

--- a/Main.hs
+++ b/Main.hs
@@ -18,16 +18,6 @@ main = do
   env <- getEnvironment
   let port = maybe 3000 read $ lookup "PORT" env
   scotty port $ do
-    get "/:channel" $ do
+    get "/" $ do
       allChannels <- liftIO $ channels
-      channelName <- param "channel"
-      let mainChannel = findChannel channelName allChannels
       html $ renderHtml $(shamletFile "index.hamlet")
-
-
-findChannel :: Text -> [DiffChannel] -> DiffChannel
-findChannel channelName chans =
-  fromJust $ lookup channelName
-    <|> lookup "nixos-unstable"
-    <|> Just (head chans)
-  where lookup n = find (\c -> dname c == n) chans

--- a/Main.hs
+++ b/Main.hs
@@ -8,6 +8,7 @@ import Control.Monad (liftM)
 import Control.Monad.Trans (liftIO)
 import Data.List (find)
 import Data.Monoid (mconcat)
+import Data.Text (Text)
 import Data.Text.Lazy (pack)
 import System.Environment (getEnvironment)
 import Text.Hamlet (shamletFile)
@@ -27,7 +28,7 @@ main = do
       html $ renderHtml $(shamletFile "index.hamlet")
 
 
-findChannel :: String -> [DiffChannel] -> DiffChannel
+findChannel :: Text -> [DiffChannel] -> DiffChannel
 findChannel channelName chans = fromJust $
                                 lookup channelName
                                 <|> lookup "nixos-unstable"

--- a/Main.hs
+++ b/Main.hs
@@ -3,13 +3,10 @@
 import Web.Scotty
 
 import Control.Applicative ((<|>))
-import Data.Maybe (fromJust)
-import Control.Monad (liftM)
 import Control.Monad.Trans (liftIO)
+import Data.Maybe (fromJust)
 import Data.List (find)
-import Data.Monoid (mconcat)
 import Data.Text (Text)
-import Data.Text.Lazy (pack)
 import System.Environment (getEnvironment)
 import Text.Hamlet (shamletFile)
 import Text.Blaze.Html.Renderer.Text (renderHtml)
@@ -29,8 +26,8 @@ main = do
 
 
 findChannel :: Text -> [DiffChannel] -> DiffChannel
-findChannel channelName chans = fromJust $
-                                lookup channelName
-                                <|> lookup "nixos-unstable"
-                                <|> Just (head chans)
+findChannel channelName chans =
+  fromJust $ lookup channelName
+    <|> lookup "nixos-unstable"
+    <|> Just (head chans)
   where lookup n = find (\c -> dname c == n) chans

--- a/Main.hs
+++ b/Main.hs
@@ -19,8 +19,8 @@ main = do
   let port = maybe 3000 read $ lookup "PORT" env
   scotty port $ do
     get "/" $ do
-      allChannels <- liftIO $ channels
+      allChannels <- liftIO channels
       html $ renderHtml $(shamletFile "index.hamlet")
     get "/api/channels" $ do
-      allChannels <- liftIO $ channels
-      json $ allChannels
+      allChannels <- liftIO channels
+      json allChannels

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ A small web application that gives the sort answer to that question, and some li
 My first web application in Haskell, built with scotty.
 
 It is running at http://howoldis.herokuapp.com
+
+# Development
+
+
+    nix-shell -p stack --run "stack build --nix --file-watch --exec howoldis"

--- a/howoldis.cabal
+++ b/howoldis.cabal
@@ -17,11 +17,13 @@ cabal-version:       >=1.10
 
 executable howoldis
   main-is:             Main.hs
-  -- other-modules:       
-  -- other-extensions:    
-  build-depends:       wreq
+  build-depends:     base >=4.8 && <5.0
+                     , wreq
                      , lens
-                     , base >=4.8 && <5.0
+                     , http-client
+                     , bytestring
+                     , split
+                     , parallel-io
                      , blaze-html >= 0.7.0
                      , mtl >= 2.1.3
                      , haquery > 0.1.1.2
@@ -30,5 +32,5 @@ executable howoldis
                      , text >= 1.2.0
                      , time >= 1.5
                      , tz
-  -- hs-source-dirs:      
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010

--- a/howoldis.cabal
+++ b/howoldis.cabal
@@ -24,9 +24,9 @@ executable howoldis
                      , base >=4.8 && <5.0
                      , blaze-html >= 0.7.0
                      , mtl >= 2.1.3
+                     , haquery > 0.1.1.2
                      , scotty >= 0.9
                      , shakespeare >= 2.0.0
-                     , tagsoup >= 0.13.3
                      , text >= 1.2.0
                      , time >= 1.5
                      , tz

--- a/howoldis.cabal
+++ b/howoldis.cabal
@@ -23,6 +23,7 @@ executable howoldis
                      , http-client
                      , bytestring
                      , split
+                     , aeson
                      , parallel-io
                      , blaze-html >= 0.7.0
                      , mtl >= 2.1.3

--- a/index.hamlet
+++ b/index.hamlet
@@ -23,8 +23,8 @@ $doctype 5
             <td>
               <span class="label label-#{dlabel chan}">#{dtime chan} ago</span>
             <td>
-              $maybe j <- jobset chan
-                <a href="http://hydra.nixos.org/job/#{j}#tabs-constituents"> Hydra
+              $maybe j <- djobset chan
+                <a href="http://hydra.nixos.org/job/#{j}#tabs-constituents"> #{j}
               $nothing
                 No tests
   <div class=container>

--- a/index.hamlet
+++ b/index.hamlet
@@ -28,23 +28,28 @@ $doctype 5
               2. Hydra build  <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>
         <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
           <div class="panel-body">
-            <p>Hydra has a jobset per channel, which polls changes every few hours and builds Nix expressions.</p>
+            <p>
+              Each channel has an associated <i>jobset</i> on <a href="http://nixos.org/hydra/">Hydra (Nix CI)</a> that is a collection of individual <i>jobs</i>. A <i>job</i> roughly corresponds to building a particular package, which itself may depend on other packages built by other <i>jobs</i>.
+            <p>
+              Before a channel can update, its associated <i>jobset</i> must be finished building, though the building of some jobs may fail.
+            <p>
+              As long as certain special <i>jobs</i> -- <i>unstable</i> for nixpkgs, and <i>tested</i> for nixos -- build successfully, the channel can update. The role of these special jobs is to ensure that essential functionality is present on each channel update.
 
-            <p>There are two major differences in those jobsets:</p>
 
-            <h3>Nixpkgs</h3>
+            <p>
+              There are two major differences between those jobsets:
 
-            These jobsets build all packages for supported platforms (Linux, Darwin).
-
-            There is an aggregate <strong>unstable</strong> job that consists of
-            most commonly used and bootstrapping packages.
-
-            <h3>NixOS</h3>
-
-            These jobsets build all packages and NixOS related things only for Linux.
-
-            There is an aggregate <strong>tested</strong> job that consists of
-            mostly NixOS tests firing up qemu instances with different kinds of configurations.
+            <ul>
+              <li>
+                <strong>nixpkgs-unstable</strong>
+                <ul>
+                  <li>builds all packages for supported platforms (Linux, Darwin)
+                  <li><a href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/release.nix#L34-L70">unstable</a> job that consists of most commonly used packages
+              <li>
+                <strong>nixos-*</strong>
+                <ul>
+                  <li>builds all packages and NixOS machinery only for Linux
+                  <li><a href="https://github.com/NixOS/nixpkgs/blob/master/nixos/release-combined.nix#L34-L105">tested</a> job that consists of mostly NixOS tests firing up qemu instances with different kinds of configurations
       <div class="panel panel-default">
         <div class="panel-heading" role="tab" id="headingThree">
           <h4 class="panel-title">
@@ -53,14 +58,14 @@ $doctype 5
         <div id="collapseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
           <div class="panel-body">
             <p>
-              For channel to be updated, two things need to be satisfied:
+              For a channel to be updated two conditions need to be satisfied:
 
             <ul>
-              <li>Particular jobset evaluation needs to be completely build ie. no more queued jobs
-              <li>Particular jobset evaluation <strong>tested/unstable</strong> needs to pass as a whole
+              <li>Particular jobset evaluation needs to be completely build ie. no more queued jobs, even if some jobs may fail
+              <li>Particular jobset evaluation <strong>tested/unstable</strong> job needs to be built succesfully
 
             <p>
-              nixos.org has a cronjob for which <a href="https://github.com/NixOS/nixos-channel-scripts">nixos-channel-scripts</a>
+              nixos.org server has a cronjob for which <a href="https://github.com/NixOS/nixos-channel-scripts">nixos-channel-scripts</a>
               are executed and poll for newest jobset that satisfies the above two conditions and trigger
               a channel update.
 
@@ -71,7 +76,7 @@ $doctype 5
               index is generated, which can take some time since it has to fetch all packages.
 
             <p>
-              <strong>nixpkgs</strong> is quickly updated since none of the above needs to happen.
+              <strong>nixpkgs</strong> is quickly updated since none of the above needs to happen once channel update is triggered.
 
     <div class=page-header>
       <h3>How up to date are NixOS channels?

--- a/index.hamlet
+++ b/index.hamlet
@@ -1,10 +1,78 @@
 $doctype 5
 <head>
   <title> "How up to date are NixOS channels?"
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js">
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 <body>
   <div class=container>
+
+    <h3>How does channel update?
+
+    <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingOne">
+          <h4 class="panel-title">
+            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+              1. Git commit  <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>
+        <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+          <div class="panel-body">
+            Anyone with commit access can push changes to either <strong>master</strong>
+            or one of the <strong>release-XX.XX</strong> branches.
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingTwo">
+          <h4 class="panel-title">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseOne">
+              2. Hydra build  <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>
+        <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
+          <div class="panel-body">
+            <p>Hydra has a jobset per channel, which polls changes every few hours and builds Nix expressions.</p>
+
+            <p>There are two major differences in those jobsets:</p>
+
+            <h3>Nixpkgs</h3>
+
+            These jobsets build all packages for supported platforms (Linux, Darwin).
+
+            There is an aggregate <strong>unstable</strong> job that consists of
+            most commonly used and bootstrapping packages.
+
+            <h3>NixOS</h3>
+
+            These jobsets build all packages and NixOS related things only for Linux.
+
+            There is an aggregate <strong>tested</strong> job that consists of
+            mostly NixOS tests firing up qemu instances with different kinds of configurations.
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingThree">
+          <h4 class="panel-title">
+            <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseThree" aria-expanded="false" aria-controls="collapseOne">
+              3. Channel update  <span class="glyphicon glyphicon-menu-down" aria-hidden="true"></span>
+        <div id="collapseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
+          <div class="panel-body">
+            <p>
+              For channel to be updated, two things need to be satisfied:
+
+            <ul>
+              <li>Particular jobset evaluation needs to be completely build ie. no more queued jobs
+              <li>Particular jobset evaluation <strong>tested/unstable</strong> needs to pass as a whole
+
+            <p>
+              nixos.org has a cronjob for which <a href="https://github.com/NixOS/nixos-channel-scripts">nixos-channel-scripts</a>
+              are executed and poll for newest jobset that satisfies the above two conditions and trigger
+              a channel update.
+
+            <p>
+              Once triggered, release files like ISOs are copied and for NixOS channel
+              <a href="https://github.com/NixOS/nixos-channel-scripts/blob/master/generate-programs-index.cc">
+                command-not-found
+              index is generated, which can take some time since it has to fetch all packages.
+
+            <p>
+              <strong>nixpkgs</strong> is quickly updated since none of the above needs to happen.
+
     <div class=page-header>
       <h1>How up to date are NixOS channels?
     <h2 class=text-center>#{dname mainChannel} is <strong>#{dtime mainChannel}</strong> old

--- a/index.hamlet
+++ b/index.hamlet
@@ -74,27 +74,29 @@ $doctype 5
               <strong>nixpkgs</strong> is quickly updated since none of the above needs to happen.
 
     <div class=page-header>
-      <h1>How up to date are NixOS channels?
-    <h2 class=text-center>#{dname mainChannel} is <strong>#{dtime mainChannel}</strong> old
+      <h3>How up to date are NixOS channels?
 
-    <h3>What about the other NixOS channels?
     <table class="table table-striped">
       <thead>
         <tr>
           <th>Channel
-          <th>Updated
-          <th>Tests
+          <th>Last updated
+          <th>Commit
+          <th>Hydra job for tests
       <tbody>
         $forall chan <- allChannels
           <tr>
             <td>
-              <a href="/#{dname chan}"> #{dname chan}
+              <a href="#{dlink chan}"> #{dname chan}
             <td>
-              <span class="label label-#{dlabel chan}">#{dtime chan} ago</span>
+              <span class="label label-#{dlabel chan}">#{dhumantime chan} ago</span>
+            <td>
+              <a href="https://github.com/NixOS/nixpkgs/commit/#{dcommit chan}"> #{dcommit chan}
             <td>
               $maybe j <- djobset chan
                 <a href="http://hydra.nixos.org/job/#{j}#tabs-constituents"> #{j}
               $nothing
                 No tests
+
   <div class=container>
     <p class=text-muted>Made by <a href="https://twitter.com/georgesdubus">Georges Dubus</a>, code is on <a href="https://github.com/madjar/howoldis">github</a>

--- a/index.hamlet
+++ b/index.hamlet
@@ -99,4 +99,4 @@ $doctype 5
                 No tests
 
   <div class=container>
-    <p class=text-muted>Made by <a href="https://twitter.com/georgesdubus">Georges Dubus</a>, code is on <a href="https://github.com/madjar/howoldis">github</a>
+     <p class=text-muted><a href="api/channels">API</a> | Made by <a href="https://twitter.com/georgesdubus">Georges Dubus</a>, code is on <a href="https://github.com/madjar/howoldis">github</a>

--- a/index.hamlet
+++ b/index.hamlet
@@ -87,13 +87,13 @@ $doctype 5
         $forall chan <- allChannels
           <tr>
             <td>
-              <a href="#{dlink chan}"> #{dname chan}
+              <a href="#{link chan}"> #{name chan}
             <td>
-              <span class="label label-#{dlabel chan}">#{dhumantime chan} ago</span>
+              <span class="label label-#{label chan}">#{humantime chan} ago</span>
             <td>
-              <a href="https://github.com/NixOS/nixpkgs/commit/#{dcommit chan}"> #{dcommit chan}
+              <a href="https://github.com/NixOS/nixpkgs/commit/#{commit chan}"> #{commit chan}
             <td>
-              $maybe j <- djobset chan
+              $maybe j <- jobset chan
                 <a href="http://hydra.nixos.org/job/#{j}#tabs-constituents"> #{j}
               $nothing
                 No tests

--- a/index.hamlet
+++ b/index.hamlet
@@ -2,6 +2,7 @@ $doctype 5
 <head>
   <title> "How up to date are NixOS channels?"
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 <body>
   <div class=container>
     <div class=page-header>

--- a/index.hamlet
+++ b/index.hamlet
@@ -61,22 +61,22 @@ $doctype 5
               For a channel to be updated two conditions need to be satisfied:
 
             <ul>
-              <li>Particular jobset evaluation needs to be completely build ie. no more queued jobs, even if some jobs may fail
-              <li>Particular jobset evaluation <strong>tested/unstable</strong> job needs to be built succesfully
+              <li>Particular jobset evaluation needs to be completely built ie. no more queued jobs, even if some jobs may fail
+              <li>Particular jobset evaluation's <strong>tested/unstable</strong> job needs to be built succesfully
 
             <p>
-              nixos.org server has a cronjob for which <a href="https://github.com/NixOS/nixos-channel-scripts">nixos-channel-scripts</a>
-              are executed and poll for newest jobset that satisfies the above two conditions and trigger
+              The nixos.org server has a cronjob for which <a href="https://github.com/NixOS/nixos-channel-scripts">nixos-channel-scripts</a>
+              are executed and poll for the newest jobset that satisfies the above two conditions and trigger
               a channel update.
 
             <p>
-              Once triggered, release files like ISOs are copied and for NixOS channel
+              Once triggered, release files such as ISOs are copied. For the NixOS channel
               <a href="https://github.com/NixOS/nixos-channel-scripts/blob/master/generate-programs-index.cc">
                 command-not-found
               index is generated, which can take some time since it has to fetch all packages.
 
             <p>
-              <strong>nixpkgs</strong> is quickly updated since none of the above needs to happen once channel update is triggered.
+              <strong>nixpkgs</strong> is quickly updated since none of the above needs to happen once a channel update is triggered.
 
     <div class=page-header>
       <h3>How up to date are NixOS channels?

--- a/index.hamlet
+++ b/index.hamlet
@@ -89,7 +89,7 @@ $doctype 5
             <td>
               <a href="#{link chan}"> #{name chan}
             <td>
-              <span class="label label-#{label chan}">#{humantime chan} ago</span>
+              <span class="label label-#{show $ label chan}">#{humantime chan} ago</span>
             <td>
               <a href="https://github.com/NixOS/nixpkgs/commit/#{commit chan}"> #{commit chan}
             <td>

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,9 @@
 flags: {}
 packages:
 - '.'
-extra-deps: []
+extra-deps:
+- haquery-0.1.1.3
+- tz-0.1.2.0
 nix:
-  enable: false
-  packages: [zlib.dev, zlib.out, pkgconfig, haskell.compiler.ghc7103]
-resolver: lts-6.7
+  packages: [git,zlib]
+resolver: lts-7.3


### PR DESCRIPTION
I've made a bunch of commit in last two days. I hope it's not too much of a hassle, but the general idea is to make howoldis more transparent about the whole process how we get a channel from a git commit.

Major improvements:
- replace `TagSoup` with `Haquery` (jQuery api in Haskell)
- use OverloadedStrings extension to simplify string types (a bit)
- enable responsive design for mobile users
- add three step explanation how channels are updated
- fetches each channel with HTTP HEAD to extract the link to the channel and thus also git commit
- adds a simple JSON view to fix #12
- add new fields to DiffChannel: times, channel link, commit hash, jobset name

A bit more information is in each commit :)

After this is online, I'll talk to Rob to host it at https://channel-status.nixos.org or similar (if that's fine with you).

![2016-10-18-204051_1001x884_scrot](https://cloud.githubusercontent.com/assets/126339/19491452/4ae4f972-9573-11e6-888d-8108bed87557.png)

cc @madjar 
