### PR TITLE
http://nixos.org/channels -> https://nixos.org/channels.

### DIFF
--- a/Channels.hs
+++ b/Channels.hs
@@ -76,7 +76,7 @@ innerText (HQ.Tag _ _ _ children) = DT.concat $ map innerText children
 
 makeChannel :: UTCTime -> RawChannel -> IO Channel
 makeChannel current channel = do
-  e <- try $ W.head_ $ unpack $ "http://nixos.org/channels/" <> rname channel
+  e <- try $ W.head_ $ unpack $ "https://nixos.org/channels/" <> rname channel
   let link = case e of
                -- We get 302 redirect with Location header, no need to go further
                -- Propagate the rest of the errors


### PR DESCRIPTION
http://nixos.org/channels/ first issues a redirect to https:// before forwarding
to actual channel URL on Cloudfront. As we don't follow the redirect chain this
broke extraction of the channel's commit. Also see #26.

Fixes #25.