### PR TITLE
Channels: add nixpkgs-18.03-darwin jobset

### DIFF
--- a/Channels.hs
+++ b/Channels.hs
@@ -138,6 +138,7 @@ toJobset c
  | c == "nixos-unstable-small" = Just "nixos/unstable-small/tested"
  | c == "nixpkgs-unstable"     = Just "nixpkgs/trunk/unstable"
  | c == "nixpkgs-17.09-darwin" = Just "nixpkgs/nixpkgs-17.09-darwin/darwin-tested"
+ | c == "nixpkgs-18.03-darwin" = Just "nixpkgs/nixpkgs-18.03-darwin/darwin-tested"
  | "nixos-" `DT.isPrefixOf` c  = Just $ "nixos/release-" <> DT.drop 6 c <> "/tested"
  | otherwise                   = Nothing
 


### PR DESCRIPTION
Currently http://howoldis.herokuapp.com shows "No tests" for the nixpkgs-18.03 darwin channel, a tested job exists at nixpkgs/nixpkgs-18.03-darwin/darwin-tested.