### PR TITLE
Update to LTS 9.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: nix
 sudo: false
 env:
-    - NIX_PATH=nixpkgs=https://d3g5gsiof5omrk.cloudfront.net/nixpkgs/nixpkgs-17.03pre93054.fad5794/nixexprs.tar.xz
+    - NIX_PATH=nixpkgs=https://d3g5gsiof5omrk.cloudfront.net/nixos/17.09/nixos-17.09.3159.c665fcca9e7/nixexprs.tar.xz
 script:
 - nix-shell -p haskellPackages.hlint --run "hlint ."
 - nix-shell -p stack --run "stack build --nix"

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - '.'
 extra-deps:
 - haquery-0.1.1.3
-- tz-0.1.2.0
+- tz-0.1.3.0
 nix:
   packages: [git,zlib]
-resolver: lts-7.3
+resolver: lts-9.21


### PR DESCRIPTION
Fixes #29.

I tried to update to latest LTS 11.0 but haquery won't build because of version bounds on base so sticking with 9.21 for now.