### PR TITLE
Channels: order by version

### DIFF
--- a/Channels.hs
+++ b/Channels.hs
@@ -44,11 +44,18 @@ data Channel = Channel { name  :: Text
                        } deriving (Show, Generic)
 instance ToJSON Channel
 
+parseVersion :: Channel -> Text
+parseVersion c = matchVersion $ DT.splitOn "-" name'
+  where name' = name c
+
+matchVersion :: [Text] -> Text
+matchVersion (_:x:_) = x
+
 instance Eq Channel where
-  s == c = name s == name c
+  s == c = parseVersion s == parseVersion c
 
 instance Ord Channel where
-  s `compare` c = name s `compare` name c
+  s `compare` c = parseVersion s `compare` parseVersion c
 
 data Label = Danger | Warning | Success | NoLabel deriving (Generic)
 instance Show Label where


### PR DESCRIPTION
Since 17.09 we always ship a `nixpkgs-$version-darwin` channel.
With the current ordering these channels will be shown *before* the
nixos-* channels.

This can be an issue when more channels `nixpkgs-*-darwin` channels will
be added for new versions and *all* (possibly EOLed) nixpkgs channels
will be shown before the maintained `nixos-*` channels, so this page
could make the NixOS project somehow look like abandonware.