### PR TITLE
Add console mode

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,20 +1,28 @@
 {-# LANGUAGE OverloadedStrings, TemplateHaskell #-}
 
-import Web.Scotty
+import Web.Scotty (scotty, get, html, json)
+import Text.PrettyPrint.Boxes (hsep, left, printBox, text, vcat)
 
-import Control.Applicative ((<|>))
 import Control.Monad.Trans (liftIO)
-import Data.Maybe (fromJust)
-import Data.List (find)
-import Data.Text (Text)
-import System.Environment (getEnvironment)
+import Data.List (transpose)
+import Data.Text (Text, unpack)
+import System.Environment (getArgs, getEnvironment)
 import Text.Hamlet (shamletFile)
 import Text.Blaze.Html.Renderer.Text (renderHtml)
 
 import Channels (Channel (..), channels, jobset)
 
+data RunType = Web | Console
 
 main = do
+  args <- getArgs
+  case parseArgs args of
+    Just Web     -> startWeb
+    Just Console -> startConsole
+    Nothing      -> print "unsupported flag"
+
+startWeb :: IO ()
+startWeb = do
   env <- getEnvironment
   let port = maybe 3000 read $ lookup "PORT" env
   scotty port $ do
@@ -24,3 +32,18 @@ main = do
     get "/api/channels" $ do
       allChannels <- liftIO channels
       json allChannels
+
+startConsole :: IO ()
+startConsole = channels >>= printTable . map attrs
+ where
+  attrs channel =
+    [ unpack $ name channel
+    , unpack $ humantime channel
+    , commit channel
+    ]
+  printTable rows = printBox $ hsep 2 left $ map (vcat left . map text) (transpose rows)
+
+parseArgs :: [String] -> Maybe RunType
+parseArgs ["--server"] = Just Web
+parseArgs []           = Just Console
+parseArgs _            = Nothing

--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ It is running at http://howoldis.herokuapp.com
 # Development
 
 
-    nix-shell -p stack --run "stack build --nix --file-watch --exec howoldis"
+    nix-shell -p stack --run "stack build --nix --file-watch --exec howoldis --
+    --server"

--- a/howoldis.cabal
+++ b/howoldis.cabal
@@ -16,7 +16,8 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 executable howoldis
-  main-is:             Main.hs
+  main-is:           Main.hs
+  other-modules:     Channels
   build-depends:     base >=4.8 && <5.0
                      , wreq
                      , lens
@@ -33,5 +34,6 @@ executable howoldis
                      , text >= 1.2.0
                      , time >= 1.5
                      , tz
+                     , boxes
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010


### PR DESCRIPTION
Hi,

This project is really useful but I don't want to run a web server just to find our nix channel information.  This PR allows howoldis run directly in the terminal and print out a nice table
```
nixos-unstable        1 day      a8c71037e04
nixos-unstable-small  7 hours    95eb2fa40e6
nixpkgs-unstable      17 hours   4756e6ff3b8
nixos-18.03           13 hours   91b286c8935
nixos-18.03-small     14 hours   91b286c8935
nixpkgs-18.03-darwin  1 day      91b286c8935
nixos-17.09           12 days    9e1d8b74706
nixos-17.09-small     6 days     be3ac859fb2
nixpkgs-17.09-darwin  5 days     be3ac859fb2
nixos-17.03           120 days   78e9665b48f
nixos-17.03-small     77 days    2c1838ab99b
nixos-16.09           396 days   25f4906da6
nixos-16.09-small     396 days   25f4906da6
nixos-16.03           449 days   dda40aa8d1
nixos-16.03-small     449 days   dda40aa8d1
nixos-15.09           560 days   3727911
nixos-15.09-small     560 days   3727911
nixos-14.12           997 days   b373bf9
nixos-14.12-small     837 days   c191689
nixos-14.04           1031 days  8a3eea0
nixos-14.04-small     1031 days  8a3eea0
nixos-13.10           1367 days  91e952a
```
Note: This is a breaking change because of the command line argument.