### PR TITLE
[PoC/RFC] Switch to background updates, pull channel info via GitHub API.

### DIFF
--- a/Channels.hs
+++ b/Channels.hs
@@ -1,124 +1,205 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
-module Channels (Channel (..), channels) where
+{-# LANGUAGE TypeApplications #-}
 
-import Control.Concurrent.ParallelIO.Global (parallelE, stopGlobalPool)
-import Control.Exception (try)
-import Control.Lens
-import Control.Monad (unless)
-import GHC.Generics
+module Channels
+  ( Channel(..)
+  , newEnv
+  , channels
+  ) where
+
+import           Control.Monad.Catch (MonadThrow)
+import           Control.Monad.Except (ExceptT(..), runExceptT)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Control.Monad.Logger (MonadLogger, logInfoN)
+import           Control.Monad.Reader (MonadReader, asks)
+import           Data.Aeson (FromJSON(..), ToJSON, withObject, (.:))
+import           Data.Bifunctor (first, second)
+import qualified Data.ByteString.Char8 as CharBytes
+import qualified Data.ByteString.Lazy as LazyBytes
+import           Data.List (sortBy)
+import           Data.Maybe (fromMaybe)
+import           Data.Monoid ((<>))
+import           Data.Proxy (Proxy(..))
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           Data.Time.Clock (NominalDiffTime, UTCTime, diffUTCTime)
+import           GHC.Generics
+import           GitHub.Auth (Auth(..))
+import           GitHub.Data (Owner)
+import qualified GitHub.Data.GitData as GitHub
+import           GitHub.Data.Name (Name)
+import           GitHub.Data.Repos (Repo)
+import           GitHub.Data.Request (Request, RW(..), query, toPathPart)
+import qualified GitHub.Endpoints.GitData.Commits as GitHub
+import           GitHub.Endpoints.Repos.Commits (Commit)
+import           GitHub.Request (executeRequestWithMgr, executeRequestWithMgr')
 import qualified Haquery as HQ
-import Data.Aeson (ToJSON)
-import Data.Either (rights, lefts)
-import Data.Maybe (fromMaybe)
-import Data.Monoid ((<>))
-import Data.List (null, sortBy)
-import Data.List.Split (splitOn)
-import Data.Time.Clock (UTCTime, NominalDiffTime, getCurrentTime, diffUTCTime)
-import Data.Time.Format (parseTimeM, defaultTimeLocale)
-import Data.Time.LocalTime (localTimeToUTC, hoursToTimeZone)
-import Data.Time.Zones
-import Data.Time.Zones.All
-import qualified Data.Text as DT
-import qualified Data.ByteString.Char8 as C8
-import Data.Text (pack, unpack, replace, Text)
-import qualified Network.Wreq as W
-import Network.Wreq.Session (Session)
-import qualified Network.Wreq.Session as WS
-import Network.HTTP.Client (HttpException(HttpExceptionRequest)
-                           , HttpExceptionContent(StatusCodeException)
-                           , responseHeaders)
+import           Network.HTTP.Client
+  ( Manager
+  , httpLbs
+  , newManager
+  , parseRequest
+  , responseBody
+  )
+import           Network.HTTP.Client.TLS (tlsManagerSettings)
+import           System.Environment (lookupEnv)
+import           UnliftIO (MonadUnliftIO)
+import           UnliftIO.Async (mapConcurrently)
 
+data HowoldisEnv = HowoldisEnv
+  { howoldisEnvManager :: Manager
+  , howoldisGitHubAuth :: Maybe Auth
+  }
 
-data RawChannel = RawChannel { rname :: Text
-                             , rtime :: Either Text UTCTime
-                             } deriving (Show)
+newEnv :: MonadIO m => m HowoldisEnv
+newEnv = do
+  mgr <- liftIO . newManager $ tlsManagerSettings
+  auth <-
+    fmap (OAuth . CharBytes.pack) <$> (liftIO . lookupEnv $ "GITHUB_TOKEN")
+  return HowoldisEnv {howoldisEnvManager = mgr, howoldisGitHubAuth = auth}
 
-data Channel = Channel { name  :: Text
-                       , label :: Label
-                       , humantime  :: Text
-                       , time :: Maybe NominalDiffTime
-                       , commit :: String
-                       , link :: String
-                       , jobset :: Maybe Text
-                       } deriving (Show, Generic)
+github ::
+     (MonadReader HowoldisEnv m, MonadIO m)
+  => GitHub.Request 'RO b
+  -> ExceptT GitHub.Error m b
+github request = do
+  mgr <- asks howoldisEnvManager
+  mAuth <- asks howoldisGitHubAuth
+  case mAuth of
+    Just auth -> ExceptT . liftIO . executeRequestWithMgr mgr auth $ request
+    Nothing -> ExceptT . liftIO . executeRequestWithMgr' mgr $ request
+
+{-# ANN
+  Branch ("HLint: ignore Use newtype instead of data" :: Text) #-}
+data Branch = Branch
+  { branchCommit :: Commit
+  }
+
+instance FromJSON Branch where
+  parseJSON = withObject "Branch" $ \o -> Branch <$> o .: "commit"
+
+branchR :: Name Owner -> Name Repo -> Name Branch -> Request k Branch
+branchR user repo branch =
+  query
+    ["repos", toPathPart user, toPathPart repo, "branches", toPathPart branch]
+    []
+
+data Channel = Channel
+  { name :: Text
+  , label :: Label
+  , humantime :: Text
+  , time :: UTCTime
+  , commit :: Text
+  , link :: Text
+  , jobset :: Maybe Text
+  } deriving (Show, Generic)
+
 instance ToJSON Channel
 
-parseVersion :: Channel -> Text
-parseVersion c = matchVersion $ DT.splitOn "-" name'
-  where name' = name c
+parseVersion :: Text -> Text
+parseVersion = matchVersion . Text.splitOn "-"
 
 matchVersion :: [Text] -> Text
 matchVersion (_:x:_) = x
+matchVersion _ = ""
 
 instance Eq Channel where
-  s == c = parseVersion s == parseVersion c
+  s == c = (parseVersion . name $ s) == (parseVersion . name $ c)
 
 instance Ord Channel where
-  s `compare` c = parseVersion s `compare` parseVersion c
+  s `compare` c = (parseVersion . name $ s) `compare` (parseVersion . name $ c)
 
-data Label = Danger | Warning | Success | NoLabel deriving (Generic)
+data Label
+  = Danger
+  | Warning
+  | Success
+  | NoLabel
+  deriving (Generic)
+
 instance Show Label where
   show Danger = "danger"
   show Warning = "warning"
   show Success = "success"
   show NoLabel = ""
+
 instance ToJSON Label
 
-parseTime :: String -> Either Text UTCTime
-parseTime = fmap (localTimeToUTCTZ tz) . parseTimeM True defaultTimeLocale "%F %R"
-  where tz = tzByLabel Europe__Rome -- CET/CEST
-
-findGoodChannels :: Text -> [RawChannel]
-findGoodChannels html = map makeChannel rows
+getChannelNames :: Text -> [Text]
+getChannelNames html = map makeChannelName rows
   where
     rows = drop 2 $ concatMap (HQ.select "tr:has(a)") $ HQ.parseHtml html
-    makeChannel tag = RawChannel name time
-      where name = replaceEscapedQuotes $ fromMaybe "" $ HQ.attr "href" $ head $ HQ.select "a" tag
-            time = parseTime $ unpack $ innerText $ head $ HQ.select "*:nth-child(3)" tag
-            -- TODO: Why do these quotes leak into tag content?
-            replaceEscapedQuotes = replace "\\\"" ""
+    makeChannelName =
+      replaceEscapedQuotes .
+      fromMaybe "" . HQ.attr "href" . head . HQ.select "a"
+    replaceEscapedQuotes = Text.replace "\\\"" ""
 
--- TODO: Remove once merged https://github.com/crufter/haquery/pull/6
-innerText :: HQ.Tag -> Text
-innerText (HQ.Doctype _ text) = text
-innerText (HQ.Text _ text) = text
-innerText (HQ.Tag _ _ _ children) = DT.concat $ map innerText children
+devBranchName :: Text -> Text
+devBranchName channel
+  | isUnstable channel = "master"
+  | otherwise =
+    let version = parseVersion channel
+     in "release-" <> version
 
-makeChannel :: Session -> UTCTime -> RawChannel -> IO Channel
-makeChannel sess current channel = do
-  e <- try $ WS.head_ sess . unpack $ "https://nixos.org/channels/" <> rname channel
-  let link = case e of
-               -- We get 302 redirect with Location header, no need to go further
-               -- Propagate the rest of the errors
-               Left (HttpExceptionRequest _ (StatusCodeException resp _)) ->
-                 C8.unpack $ snd $ head $ filter ((== "Location") . fst) . responseHeaders $ resp
-               Right response -> C8.unpack $ response ^. W.responseHeader "Location"
-  let diff = diffUTCTime current <$> rtime channel
-  return $ Channel (rname channel)
-                    (diffToLabel diff)
-                    (either id humanTimeDiff diff)
-                    (either (const Nothing) Just diff)
-                    (parseCommit link)
-                    link
-                    (toJobset $ rname channel)
+isUnstable :: Text -> Bool
+isUnstable channel = "unstable" `Text.isInfixOf` channel
 
+releasedBranchName :: Text -> Text
+releasedBranchName channel = channel
 
-parseCommit :: String -> String
-parseCommit url = last $ splitOn "." url
+makeChannel ::
+     (MonadLogger m, MonadIO m, MonadReader HowoldisEnv m)
+  => Text
+  -> m (Either GitHub.Error Channel)
+makeChannel channel =
+  runExceptT $ do
+    dev <- latestCommitFor "nixpkgs" (devBranchName channel)
+    released <- latestCommitFor "nixpkgs-channels" (releasedBranchName channel)
+    let commitTime =
+          GitHub.gitUserDate .
+          GitHub.gitCommitCommitter . GitHub.commitGitCommit
+        devTime = commitTime dev
+        releasedTime = commitTime released
+        diff = diffUTCTime devTime releasedTime
+        ch =
+          Channel
+            { name = channel
+            , label = diffToLabel diff
+            , humantime = humanTimeDiff diff
+            , time = releasedTime
+            , commit =
+                Text.take 11 . GitHub.untagName . GitHub.commitSha $ released
+            , link = "https://nixos.org/channels/" <> channel
+            , jobset = toJobset channel
+            }
+    ExceptT . return . Right $ ch
 
--- |The list of the current NixOS channels
-channels :: IO [Channel]
-channels =
-  WS.withAPISession $ \sess -> do
-    r <- WS.get sess "https://nixos.org/channels/"
-    current <- getCurrentTime
-    let html = pack $ show $ r ^. W.responseBody
-    responseOrExc <- parallelE $
-      makeChannel sess current <$> findGoodChannels html
-    unless (null $ lefts responseOrExc) $ print $ lefts responseOrExc
-    return $ sortBy (flip compare) $ rights responseOrExc
+latestCommitFor ::
+     (MonadLogger m, MonadIO m, MonadReader HowoldisEnv m)
+  => Text
+  -> Text
+  -> ExceptT GitHub.Error m Commit
+latestCommitFor repo branch = do
+  logInfoN $ "Fetching " <> branch <> " of " <> repo
+  fmap branchCommit .
+    github . branchR "NixOS" (GitHub.mkName (Proxy :: Proxy Repo) repo) $
+    GitHub.mkName (Proxy :: Proxy Branch) branch
 
+-- | The list of the current NixOS channels
+channels ::
+     (MonadLogger m, MonadReader HowoldisEnv m, MonadUnliftIO m, MonadThrow m)
+  => m (Either Text [Channel])
+channels = do
+  rq <- parseRequest "https://nixos.org/channels"
+  mgr <- asks howoldisEnvManager
+  r <- liftIO . httpLbs rq $ mgr
+  let html = Text.decodeUtf8 . LazyBytes.toStrict . responseBody $ r
+  responseOrExc <- mapConcurrently makeChannel . getChannelNames $ html
+  return . first (Text.pack . show) . second (sortBy (flip compare)) . sequenceA $
+    responseOrExc
 
 humanTimeDiff :: NominalDiffTime -> Text
 humanTimeDiff d
@@ -126,32 +207,34 @@ humanTimeDiff d
   | hours > 1 = doShow hours (pluralize hours "hour" "hours")
   | minutes > 1 = doShow minutes (pluralize minutes "minute" "minutes")
   | otherwise = doShow d (pluralize d "second" "seconds")
-  where minutes = d / 60
-        hours = minutes / 60
-        days = hours / 24
-        doShow x unit = pack (show $ truncate x) <> " " <> unit
-
+  where
+    minutes = d / 60
+    hours = minutes / 60
+    days = hours / 24
+    doShow x unit = Text.pack (show @ Integer $ truncate x) <> " " <> unit
         -- diffUTCTime contains a float-like value, so everything below `2` will be treated as 1
         -- Furthermore a 0 causes the next lower unit, so only 2 and more will be interpreted
         -- as plural.
-        pluralize d s p
-          | d < 2 = s
-          | otherwise = p
+    pluralize d' s p
+      | d' < 2 = s
+      | otherwise = p
 
 toJobset :: Text -> Maybe Text
 toJobset c
- | c == "nixos-unstable"       = Just "nixos/trunk-combined/tested"
- | c == "nixos-unstable-small" = Just "nixos/unstable-small/tested"
- | c == "nixpkgs-unstable"     = Just "nixpkgs/trunk/unstable"
- | "nixos-" `DT.isPrefixOf` c  = Just $ "nixos/release-" <> DT.drop 6 c <> "/tested"
- | "-darwin" `DT.isSuffixOf` c = Just $ "nixpkgs/" <> c <> "/darwin-tested"
- | otherwise                   = Nothing
+  | c == "nixos-unstable" = Just "nixos/trunk-combined/tested"
+  | c == "nixos-unstable-small" = Just "nixos/unstable-small/tested"
+  | c == "nixpkgs-unstable" = Just "nixpkgs/trunk/unstable"
+  | "nixos-" `Text.isPrefixOf` c =
+    Just $ "nixos/release-" <> Text.drop 6 c <> "/tested"
+  | "-darwin" `Text.isSuffixOf` c = Just $ "nixpkgs/" <> c <> "/darwin-tested"
+  | otherwise = Nothing
 
 -- | Takes time since last update to the channel and colors it based on it's age
-diffToLabel :: Either Text NominalDiffTime -> Label
-diffToLabel (Left _) = NoLabel
-diffToLabel (Right time)
+diffToLabel :: NominalDiffTime -> Label
+diffToLabel t
   | days < 3 = Success
   | days < 10 = Warning
   | otherwise = Danger
-    where days = time / (60 * 60 * 24)
+  where
+    days = t / (60 * 60 * 24)
+

--- a/Main.hs
+++ b/Main.hs
@@ -1,26 +1,73 @@
 {-# LANGUAGE OverloadedStrings, TemplateHaskell #-}
 
-import Web.Scotty
+import           Channels (Channel(..), jobset, newEnv)
+import qualified Channels (channels)
+import           Control.Concurrent (ThreadId, threadDelay)
+import           Control.Concurrent.STM
+  ( atomically
+  , newTVar
+  , readTVarIO
+  , writeTVar
+  )
+import           Control.Concurrent.Supervisor
+  ( QueueLike
+  , RestartStrategy(..)
+  , Supervisor0
+  , forkSupervised
+  , newSupervisor
+  , newSupervisorSpec
+  )
+import           Control.Monad (forever, void)
+import           Control.Monad.IO.Unlift (MonadUnliftIO, withRunInIO)
+import           Control.Monad.Logger (logErrorN, logInfoN, runStderrLoggingT)
+import           Control.Monad.Reader (runReaderT)
+import           Control.Monad.Trans (liftIO)
+import           Control.Retry (RetryPolicyM, constantDelay)
+import           Data.Monoid ((<>))
+import qualified Data.Text as Text
+import           System.Environment (getEnvironment)
+import           Text.Blaze.Html.Renderer.Text (renderHtml)
+import           Text.Hamlet (shamletFile)
+import           Web.Scotty
 
-import Control.Applicative ((<|>))
-import Control.Monad.Trans (liftIO)
-import Data.Maybe (fromJust)
-import Data.List (find)
-import Data.Text (Text)
-import System.Environment (getEnvironment)
-import Text.Hamlet (shamletFile)
-import Text.Blaze.Html.Renderer.Text (renderHtml)
+forkSupervised' ::
+     (QueueLike q, MonadUnliftIO m)
+  => Supervisor0 q
+  -> RetryPolicyM IO
+  -> m ()
+  -> m ThreadId
+forkSupervised' s p a = withRunInIO $ \run -> forkSupervised s p (run a)
 
-import Channels (Channel (..), channels, jobset)
-
-
+main :: IO ()
 main = do
   env <- getEnvironment
   let port = maybe 3000 read $ lookup "PORT" env
-  scotty port $ do
-    get "/" $ do
-      allChannels <- liftIO channels
-      html $ renderHtml $(shamletFile "index.hamlet")
-    get "/api/channels" $ do
-      allChannels <- liftIO channels
-      json allChannels
+  supervisor <- newSupervisor =<< newSupervisorSpec OneForOne
+  howoldisEnv <- newEnv
+  flip runReaderT howoldisEnv $
+    runStderrLoggingT $ do
+      initial <- Channels.channels
+      channels <-
+        liftIO . atomically . newTVar $
+        case initial of
+          Right xs -> xs
+          Left _ -> []
+      void $
+        forkSupervised' supervisor (constantDelay 10000000) $
+        forever $ do
+          liftIO . threadDelay $ 60 * 1000000
+          new <- Channels.channels
+          case new of
+            Left e -> do
+              logErrorN $
+                "Failed to update channels: " <> (Text.pack . show $ e)
+              error "restart me please"
+            Right xs -> liftIO . atomically . writeTVar channels $ xs
+          logInfoN "Updated channels"
+      liftIO . scotty port $ do
+        get "/" $ do
+          allChannels <- liftIO . readTVarIO $ channels
+          html $ renderHtml $(shamletFile "index.hamlet")
+        get "/api/channels" $ do
+          allChannels <- liftIO . readTVarIO $ channels
+          json allChannels

--- a/howoldis.cabal
+++ b/howoldis.cabal
@@ -17,21 +17,27 @@ cabal-version:       >=1.10
 
 executable howoldis
   main-is:             Main.hs
-  build-depends:     base >=4.8 && <5.0
-                     , wreq
-                     , lens
-                     , http-client
-                     , bytestring
-                     , split
-                     , aeson
-                     , parallel-io
-                     , blaze-html >= 0.7.0
-                     , mtl >= 2.1.3
-                     , haquery > 0.1.1.2
-                     , scotty >= 0.9
-                     , shakespeare >= 2.0.0
-                     , text >= 1.2.0
-                     , time >= 1.5
-                     , tz
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  other-modules:       Channels
+  build-depends:     aeson
+                   , base >=4.8 && <5.0
+                   , blaze-html >= 0.7.0
+                   , blaze-markup
+                   , bytestring
+                   , exceptions
+                   , github
+                   , haquery > 0.1.1.2
+                   , http-client
+                   , http-client-tls
+                   , monad-logger
+                   , mtl >= 2.1.3
+                   , retry
+                   , scotty >= 0.9
+                   , shakespeare >= 2.0.0
+                   , stm
+                   , text >= 1.2.0
+                   , threads-supervisor
+                   , time >= 1.5
+                   , unliftio
+                   , unliftio-core
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010

--- a/index.hamlet
+++ b/index.hamlet
@@ -85,7 +85,7 @@ $doctype 5
       <thead>
         <tr>
           <th>Channel
-          <th>Last updated
+          <th>Time since last commit
           <th>Commit
           <th>Hydra job for tests
       <tbody>
@@ -94,9 +94,9 @@ $doctype 5
             <td>
               <a href="#{link chan}"> #{name chan}
             <td>
-              <span class="label label-#{show $ label chan}">#{humantime chan} ago
+              <span class="label label-#{show $ label chan}" title="#{show $ time chan}">#{humantime chan}
             <td>
-              <a href="https://github.com/NixOS/nixpkgs/commit/#{commit chan}"> #{commit chan}
+              <a href="https://github.com/NixOS/nixpkgs/commit/#{commit chan}">#{commit chan}
             <td>
               $maybe j <- jobset chan
                 <a href="http://hydra.nixos.org/job/#{j}#tabs-constituents"> #{j}

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
 extra-deps:
 - haquery-0.1.1.3
 - tz-0.1.3.0
+- threads-supervisor-1.1.0.0
 nix:
   packages: [git,zlib]
 resolver: lts-9.21


### PR DESCRIPTION
Ended up writing this little experiment and figured might as well share.

This switches the update process to an updater running on a background thread updating an in-memory cache of channel information on a fixed interval (in the current implementation every 60 seconds).

As previously the list of channels is retrieved from https://nixos.org/channels/ however the freshness information is retrieved via GitHub API. For each channel a lookup is performed against its respective branch on NixOS/nixpkgs and NixOS/nixpkgs-channels and the freshness is computed as the time difference between the latest commits on the branches.

If `GITHUB_TOKEN` env variable is set the requests to GitHub will be authenticated which increases the number of requests per hour that can be performed to the API, and thus frequency of updates.

At the moment the code does few more requests than it strictly needs but I haven't looked into optimising that part (which would probably complicate the code even more). The are probably few more things to tweak like the update interval, retry frequency on failures, etc.

(Sorry for the large diff, applied hindent out of habit so there is a fair amount of purely formatting changes :/).